### PR TITLE
add POST /api/topics endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -47,6 +47,36 @@ describe("/api", () => {
           });
       });
     });
+    describe("POST /api/topics", () => {
+      test("201; Responds with posted topic", () => {
+        return request(app)
+          .post("/api/topics")
+          .send({
+            slug: "bananas",
+            description: "This is a very interesting topic",
+          })
+          .expect(201)
+          .then(({ body: { topic } }) => {
+            //check response matches post input data and has correct properties
+            expect(topic).toMatchObject({
+              slug: "bananas",
+              description: "This is a very interesting topic",
+              img_url: "",
+            });
+          });
+      });
+      test("400; Responds 'Topic is missing properties' when properties are missing", () => {
+        return request(app)
+          .post("/api/topics")
+          .send({
+            slug: "bananas",
+          })
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("Topic is missing properties");
+          });
+      });
+    });
   });
   describe("/articles", () => {
     describe("/articles", () => {

--- a/endpoints.json
+++ b/endpoints.json
@@ -14,6 +14,23 @@
       ]
     }
   },
+  "POST /api/topics": {
+    "description": "creates a new topic and serves the new topic",
+    "queries": [],
+    "exampleRequest": {
+      "slug": "football",
+      "description": "Footie!"
+    },
+    "exampleResponse": {
+      "topics": [
+        {
+          "slug": "football",
+          "description": "Footie!",
+          "img_url": ""
+        }
+      ]
+    }
+  },
   "GET /api/articles": {
     "description": "serves an array of all articles",
     "queries": ["sort_by", "order", "topic", "limit", "p"],

--- a/src/controllers/topics.controller.js
+++ b/src/controllers/topics.controller.js
@@ -1,4 +1,4 @@
-const { selectTopics } = require("../models/topics.model");
+const { selectTopics, insertTopic } = require("../models/topics.model");
 
 async function getTopics(req, res, next) {
   try {
@@ -9,6 +9,22 @@ async function getTopics(req, res, next) {
   }
 }
 
+async function postTopic(req, res, next) {
+  const { slug, description, img_url } = req.body;
+
+  if (!slug || !description) {
+    return res.status(400).send({ msg: "Topic is missing properties" });
+  }
+
+  try {
+    const topic = await insertTopic(slug, description, img_url);
+    res.status(201).send({ topic });
+  } catch (err) {
+    next(err);
+  }
+}
+
 module.exports = {
   getTopics,
+  postTopic,
 };

--- a/src/models/topics.model.js
+++ b/src/models/topics.model.js
@@ -9,6 +9,21 @@ async function selectTopics() {
   return rows;
 }
 
+async function insertTopic(slug, description, img_url = "") {
+  const insertResult = await db.query(
+    `INSERT INTO
+        topics 
+        (slug, description, img_url)
+      VALUES 
+        ($1,$2, $3) 
+      RETURNING *`,
+    [slug, description, img_url]
+  );
+
+  return insertResult.rows[0];
+}
+
 module.exports = {
   selectTopics,
+  insertTopic,
 };

--- a/src/routers/topics.router.js
+++ b/src/routers/topics.router.js
@@ -2,8 +2,8 @@ const express = require("express");
 const router = new express.Router();
 
 //topics.controller
-const { getTopics } = require("../controllers/topics.controller");
+const { getTopics, postTopic } = require("../controllers/topics.controller");
 
-router.route("/").get(getTopics);
+router.route("/").get(getTopics).post(postTopic);
 
 module.exports = router;


### PR DESCRIPTION
Added ability to create new topics via POST /api/topics. Requires slug and description in request body.